### PR TITLE
fix: guard worker count in enumeration mode

### DIFF
--- a/cpp_extension/src/module_optimizer.cpp
+++ b/cpp_extension/src/module_optimizer.cpp
@@ -200,6 +200,11 @@ std::vector<ModuleSolution> ModuleOptimizerCpp::StrategyEnumeration(
     const std::unordered_map<int, int>& min_attr_sum_requirements,
     int max_solutions,
     int max_workers) {
+    // 防御性编程：在极端环境下传入的线程数可能为 0，进而在后续的批次计算
+    // 中触发除零异常。这里进行保护，确保至少启用 1 个工作线程。
+    if (max_workers < 1) {
+        max_workers = 1;
+    }
 
     std::vector<ModuleInfo> candidate_modules = modules;
     // 计算组合


### PR DESCRIPTION
## Summary
- ensure enumeration uses at least one worker thread after CPU detection failures
- add defensive check in C++ StrategyEnumeration to avoid division by zero

## Testing
- `python -m py_compile module_optimizer.py`
- `g++ -std=c++17 -Icpp_extension/src -fsyntax-only cpp_extension/src/module_optimizer.cpp`

------
https://chatgpt.com/codex/tasks/task_e_68bc46ea22ac833080a6d35ec5253861